### PR TITLE
ポータルチェックを簡単に実行するスクリプトを追加しました。

### DIFF
--- a/run-portalCheck.sh
+++ b/run-portalCheck.sh
@@ -1,0 +1,2 @@
+npm run build
+node build/scripts/portalCheck.js

--- a/src/scripts/portalCheck.ts
+++ b/src/scripts/portalCheck.ts
@@ -1,0 +1,9 @@
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+require('dotenv').config();
+
+import {
+  portalCheckMainTask,
+} from '../tasks/syncs/portalCheck/portalCheckMainTask';
+
+
+portalCheckMainTask(true);


### PR DESCRIPTION
## 何

- scriptフォールだーを追加しました。
- ポータルチェックを実行するスクリプトを追加しました。

## なぜ

- Cronで自動実行になっていますが、対象サイト更新やネットワーク障害やパソコン自体障害などで、実行出来ないときがあります。
- #5 


## 使い方

- レポジトリのフォールだーを開く
- `run-portalcheck.sh`　を実行する

※　止めたい時は、ctrl + c